### PR TITLE
Improve contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ git push origin master
 
 #### Alternative
 
+`git fetch` only downloads the changes from the upstream and doesn't integrate those into your forked repository. You have to use an additional command `git merge` to do so. Alternatively, `git pull` not only downloads the changes but also integrate those into your forked repository.
+
 Set up  the original repository as your upstream.
 ```
 git remote add upstream https://github.com/The-Codesis/simple-static-website.git

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ At this point, your local branch is synced to the original repository's master b
 ```
 git push origin master
 ```
+
+#### Alternative
+
+Set up  the original repository as your upstream.
+```
+git remote add upstream https://github.com/The-Codesis/simple-static-website.git
+```
+Now, fetch and merge the changes from the original repository simultaneously.
+```
+git pull upstream master
+```
+Update your forked Github repository.
+```
+git push origin master
+```
+
 To summarize, see the section below.
 
 ### Get latest version

--- a/README.md
+++ b/README.md
@@ -100,6 +100,41 @@ git merge upstream/master
 git push
 ```
 
+### Git Merge VS Git Rebase
+
+Rebasing and merging are both used for integrating changes from one branch into another—but they do it in different ways.
+
+Instead of 
+```
+git merge upstream/master
+```
+you can also use
+```
+git rebase upstream/master
+```
+#### The Merge Option
+
+`git merge` will integrate the histories of the upstream branch and your master branch, giving you a branch structure that looks like:
+
+![IMAGE](https://wac-cdn.atlassian.com/dam/jcr:e229fef6-2c2f-4a4f-b270-e1e1baa94055/02.svg?cdnVersion=1060)
+
+Merging preserves history since, the existing branches are not changed in any way.Merging adds a new commit to the history. 
+
+#### The Rebase Option
+
+`git rebase` will move the entire upstream branch on the tip of your master branch, giving you a branch structure that looks like:
+
+![IMAGE](https://wac-cdn.atlassian.com/dam/jcr:5b153a22-38be-40d0-aec8-5f2fffc771e5/03.svg?cdnVersion=1060)
+
+Rebasing re-writes the history by creating brand new commits for each commit in the original branch.
+
+#### Which command to prefer?
+
+`git rebase` is usually preferred over `git merge` because
+>- It results in a perfectly linear and readable history.
+>- It eliminates the unnecessary merge commits required by git merge. 
+>- It can remove undesired commits or squash two or more commits into one.
+
 ### Create a branch to do your work.
 
 A good practice is to call the branch in the form of GH-<issue-number> followed by the title of the issue. This makes it easier to find out the issue you are trying to solve and helps us to understand what is done in the branch. Calling a branch my-work is confusing. Names of a branch can not have a space, and should be replaced with a hyphen.


### PR DESCRIPTION
fixes #27 

`git merge` integrates the histories of the upstream branch and your master branch. Merging preserves history since the existing branches are not changed in any way.
`git rebase` moves the entire upstream branch on the tip of your master branch. Rebasing re-writes history by creating brand new commits for each commit in the original branch.

- [x] Do some self-research and state differences between both commands and make the explanation apparent in commit message.
- [x] Mention these intricacies in contribution guidelines.
- [x] Add reasons explaining which command is preferred.